### PR TITLE
Fix containerd import fallback and default mode

### DIFF
--- a/common/containerd.py
+++ b/common/containerd.py
@@ -1,3 +1,9 @@
+import os
+
+# Use the pure Python protobuf implementation to avoid descriptor errors when
+# containerd's generated stubs are built with an older protoc version.
+os.environ.setdefault("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION", "python")
+
 try:
     from containerd.services.containers.v1 import containers_pb2, containers_pb2_grpc
     from containerd.services.namespaces.v1 import namespace_pb2, namespace_pb2_grpc  # For listing namespaces

--- a/common/containerd.py
+++ b/common/containerd.py
@@ -1,11 +1,9 @@
-try: 
+try:
     from containerd.services.containers.v1 import containers_pb2, containers_pb2_grpc
     from containerd.services.namespaces.v1 import namespace_pb2, namespace_pb2_grpc  # For listing namespaces
     from containerd.services.tasks.v1 import tasks_pb2, tasks_pb2_grpc  # For listing tasks
-except TypeError as e:
-    print("Running in docker-only mode")
-    ENV = "Docker"
-except AttributeError as e:
+    ENV = "k8s"
+except (TypeError, AttributeError, ImportError) as e:
     print("Running in docker-only mode")
     ENV = "Docker"
     
@@ -15,7 +13,6 @@ except AttributeError as e:
 import grpc
 import argparse
 import json
-ENV = "k8s"
 
 DEFAULT_CAPABILITIES = [
     "CAP_AUDIT_WRITE",

--- a/web.py
+++ b/web.py
@@ -194,7 +194,8 @@ def run_seccomp_diff(reduce=True, only_diff=True, only_dangerous=False):
 
 if __name__ == '__main__':
     app.debug = True
-    if app.debug: 
+    if app.debug:
         app.config["PROPAGATE_EXCEPTIONS"] = True
-    app.config["MODE"] = "k8s"
+    # Default to containerd.ENV to avoid errors when containerd is unavailable
+    app.config["MODE"] = containerd.ENV
     app.run(host='0.0.0.0', port=5000, debug=True)


### PR DESCRIPTION
## Summary
- fallback to docker mode if containerd gRPC libraries aren't installed
- default web UI to docker mode when containerd modules are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685469667dbc832ca6c04b54ed62ca55