### PR TITLE
Add vagrant-based k3s tool

### DIFF
--- a/tools/vagrant-k3s/README.md
+++ b/tools/vagrant-k3s/README.md
@@ -1,0 +1,18 @@
+# Vagrant k3s Cluster
+
+This tool provisions a three-node k3s cluster using Vagrant. The cluster
+consists of one master and two workers running Ubuntu 22.04.
+
+## Usage
+
+```bash
+cd tools/vagrant-k3s
+vagrant up
+# kubeconfig will be written to ./kubeconfig
+export KUBECONFIG=$(pwd)/kubeconfig
+kubectl get nodes
+```
+
+The API server listens on the master's private IP `192.168.56.10`. The kubeconfig
+file is patched by the provisioning script so it can be used directly from the
+host machine.

--- a/tools/vagrant-k3s/Vagrantfile
+++ b/tools/vagrant-k3s/Vagrantfile
@@ -1,0 +1,37 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/jammy64"
+  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+
+  nodes = {
+    "master" => "192.168.56.10",
+    "worker1" => "192.168.56.11",
+    "worker2" => "192.168.56.12"
+  }
+
+  nodes.each do |name, ip|
+    config.vm.define name do |node|
+      node.vm.hostname = name
+      node.vm.network "private_network", ip: ip
+      node.vm.network "forwarded_port", guest: 6443, host: 6443 if name == "master"
+      node.vm.provider :virtualbox do |vb|
+        vb.memory = 2048
+        vb.cpus = 2
+      end
+
+      if name == "master"
+        node.vm.provision "shell", inline: <<-SHELL
+          curl -sfL https://get.k3s.io | sh -s - --write-kubeconfig-mode=644
+          sudo cp /etc/rancher/k3s/k3s.yaml /vagrant/kubeconfig
+          sudo sed -i 's/127.0.0.1/192.168.56.10/' /vagrant/kubeconfig
+          sudo cat /var/lib/rancher/k3s/server/node-token > /vagrant/token
+        SHELL
+      else
+        node.vm.provision "shell", inline: <<-SHELL
+          until [ -f /vagrant/token ]; do sleep 2; done
+          TOKEN=$(cat /vagrant/token)
+          curl -sfL https://get.k3s.io | K3S_URL=https://192.168.56.10:6443 K3S_TOKEN=$TOKEN sh -
+        SHELL
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add tool to spin up three node k3s cluster using vagrant

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bcc' and 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_685564f64310832c89e102fca9b01918