### PR TITLE
Introduce agent DaemonSet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,14 @@ RUN pip install --no-cache-dir --upgrade pip && \
 COPY common /app/common
 COPY lib /app/lib
 COPY web /app/web
+COPY agent /app/agent
 COPY ./*.py /app/
 
 # Set Flask environment variables
 ENV FLASK_APP=web.py
 ENV FLASK_RUN_HOST=0.0.0.0
 ENV FLASK_ENV=development
+ENV PYTHONPATH=/app:$PYTHONPATH
 
 # Expose Flask's port
 EXPOSE 5000

--- a/README.md
+++ b/README.md
@@ -88,13 +88,14 @@ sudo python web.py
 
 Example Docker run:
 ```bash
-docker run --rm -it \                                                                                                     
+docker run --rm -it \
   --pid=host --privileged \                            
   --cap-add=SYS_PTRACE \                                             
-  --security-opt seccomp=unconfined -v /var/run/docker.sock:/var/run/docker.sock \  
+  --security-opt seccomp=unconfined -v /var/run/docker.sock:/var/run/docker.sock \
   -v /proc:/host/proc:ro -v /run/containerd/containerd.sock:/run/containerd/containerd.sock \
   antitree/seccomp-diff
 ```
+If running on k3s, mount `/run/k3s/containerd/containerd.sock` instead of `/run/containerd/containerd.sock`.
 
 
 Example helm chart:
@@ -108,6 +109,11 @@ environment variable on the web deployment to a comma-separated list of agent
 service URLs (for example `http://seccomp-diff-agent.seccomp-diff.svc.cluster.local:8000`).
 The web interface will query each agent for container details and seccomp
 summaries.
+
+If your environment uses a non-standard location for the containerd socket
+(for example `/run/k3s/containerd/containerd.sock` on k3s), update the Helm
+value `agent.containerdSocket` accordingly.  The agent will also try to guess
+between the common containerd and k3s paths when no value is provided.
 
 ### New DaemonSet Architecture
 

--- a/README.md
+++ b/README.md
@@ -123,13 +123,10 @@ privileges because all low level operations are handled by the agents.
 
 Example k8s deployment
 ```yaml
-Example k8s deployment:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: seccomp-diff
-  labels:
-    app: seccomp-diff
 spec:
   replicas: 1
   selector:
@@ -140,38 +137,14 @@ spec:
       labels:
         app: seccomp-diff
     spec:
-      hostPID: true
       containers:
       - name: seccomp-diff
         image: antitree/seccomp-diff:latest
-        securityContext:
-          privileged: true  
-          capabilities:
-            add:
-            - SYS_PTRACE  
-        volumeMounts:
-        - name: host-proc
-          mountPath: /host/proc
-          readOnly: true
-        - name: docker-socket
-          mountPath: /var/run/docker.sock  # OPTIONAL for Docker
-        - name: containerd-socket
-          mountPath: /var/run/containerd/containerd.sock  
         env:
-        - name: PROC_PATH
-          value: "/host/proc"
+        - name: AGENT_ENDPOINTS
+          value: "http://seccomp-diff-agent.seccomp-diff.svc.cluster.local:8000"
         command: ["flask"]
         args: ["run", "--debug"]
-      volumes:
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: docker-socket
-        hostPath:
-          path: /var/run/docker.sock  # Host path for Docker socket
-      - name: containerd-socket
-        hostPath:
-          path: /var/run/containerd/containerd.sock  # Host path for Docker socket
 ```
 ---
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,24 @@ helm install seccomp-diff charts/seccomp-diff
 kubectl port-forward service/seccomp-diff 5000:5000
 ```
 
+When running inside Kubernetes with the agent DaemonSet, set the `AGENT_ENDPOINTS`
+environment variable on the web deployment to a comma-separated list of agent
+service URLs (for example `http://seccomp-diff-agent.seccomp-diff.svc.cluster.local:8000`).
+The web interface will query each agent for container details and seccomp
+summaries.
+
+### New DaemonSet Architecture
+
+`seccomp-diff` can now be deployed in two parts: a lightweight web interface and
+an agent that runs as a DaemonSet on every node.  The agent collects container
+information, communicates with containerd and extracts seccomp bytecode.  The
+web service queries each agent over HTTP and aggregates the results so a single
+instance can display seccomp information for the whole cluster.
+
+To deploy the agent use the provided `agent-daemonset.yaml` and
+`agent-service.yaml` templates.  The web deployment no longer requires host
+privileges because all low level operations are handled by the agents.
+
 Example k8s deployment
 ```yaml
 Example k8s deployment:
@@ -159,7 +177,8 @@ spec:
 
 ## Current Limitations
 * [ ] Only visually diffs x86_64 for now
-* [ ] For k8s, can only dump the Node's containers that it's installed on. It needs to be ported to a Daemonset to get the whole cluster
+* [ ] For k8s, data is gathered by a node agent DaemonSet. Additional features
+      like RBAC hardening are still in progress
 
 
 ## Related work

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -4,8 +4,16 @@ import os
 
 app = Flask(__name__)
 
-# Namespace and socket path can be configured via env vars
-CONTAINERD_SOCKET = os.getenv("CONTAINERD_SOCKET", "/run/containerd/containerd.sock")
+# Namespace and socket path can be configured via env vars. If the socket
+# isn't provided, attempt to guess common paths used by containerd and k3s.
+CONTAINERD_SOCKET = os.getenv("CONTAINERD_SOCKET")
+if not CONTAINERD_SOCKET:
+    for guess in ("/run/containerd/containerd.sock", "/run/k3s/containerd/containerd.sock"):
+        if os.path.exists(guess):
+            CONTAINERD_SOCKET = guess
+            break
+    else:
+        CONTAINERD_SOCKET = "/run/containerd/containerd.sock"
 NAMESPACE = os.getenv("CONTAINER_NAMESPACE", "k8s.io")
 AGENT_ID = os.getenv("HOSTNAME", "agent")
 

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -1,0 +1,28 @@
+from flask import Flask, jsonify
+from common import containerd, ptrace
+import os
+
+app = Flask(__name__)
+
+# Namespace and socket path can be configured via env vars
+CONTAINERD_SOCKET = os.getenv("CONTAINERD_SOCKET", "/run/containerd/containerd.sock")
+NAMESPACE = os.getenv("CONTAINER_NAMESPACE", "k8s.io")
+AGENT_ID = os.getenv("HOSTNAME", "agent")
+
+@app.route('/containers', methods=['GET'])
+def list_containers():
+    """Return container details for this node."""
+    info = containerd.get_containers(containerd_socket=CONTAINERD_SOCKET, namespace=NAMESPACE)
+    for item in info.values():
+        item["agent"] = AGENT_ID
+    return jsonify(info)
+
+@app.route('/seccomp/<int:pid>', methods=['GET'])
+def seccomp(pid):
+    """Return seccomp details for a given PID."""
+    filters, dis = ptrace.get_seccomp_filters(pid)
+    summary = dis.syscallSummary if dis else {}
+    return jsonify({"pid": pid, "filters": filters, "summary": summary})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -30,7 +30,13 @@ def seccomp(pid):
     """Return seccomp details for a given PID."""
     filters, dis = ptrace.get_seccomp_filters(pid)
     summary = dis.syscallSummary if dis else {}
-    return jsonify({"pid": pid, "filters": filters, "summary": summary})
+    default_action = dis.defaultAction if dis else None
+    return jsonify({
+        "pid": pid,
+        "filters": filters,
+        "summary": summary,
+        "defaultAction": default_action,
+    })
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8000)

--- a/charts/seccomp-diff/templates/agent-daemonset.yaml
+++ b/charts/seccomp-diff/templates/agent-daemonset.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: seccomp-diff-agent
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: seccomp-diff-agent
+spec:
+  selector:
+    matchLabels:
+      app: seccomp-diff-agent
+  template:
+    metadata:
+      labels:
+        app: seccomp-diff-agent
+    spec:
+      hostPID: true
+      containers:
+      - name: agent
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["python", "agent/agent.py"]
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - SYS_PTRACE
+        volumeMounts:
+        - name: host-proc
+          mountPath: /host/proc
+          readOnly: true
+        - name: containerd-socket
+          mountPath: /run/containerd/containerd.sock
+      volumes:
+      - name: host-proc
+        hostPath:
+          path: /proc
+      - name: containerd-socket
+        hostPath:
+          path: /run/containerd/containerd.sock

--- a/charts/seccomp-diff/templates/agent-daemonset.yaml
+++ b/charts/seccomp-diff/templates/agent-daemonset.yaml
@@ -33,11 +33,14 @@ spec:
           mountPath: /host/proc
           readOnly: true
         - name: containerd-socket
-          mountPath: /run/containerd/containerd.sock
+          mountPath: {{ .Values.agent.containerdSocket }}
+        env:
+        - name: CONTAINERD_SOCKET
+          value: {{ .Values.agent.containerdSocket | quote }}
       volumes:
       - name: host-proc
         hostPath:
           path: /proc
       - name: containerd-socket
         hostPath:
-          path: /run/containerd/containerd.sock
+          path: {{ .Values.agent.containerdSocket }}

--- a/charts/seccomp-diff/templates/agent-daemonset.yaml
+++ b/charts/seccomp-diff/templates/agent-daemonset.yaml
@@ -19,7 +19,10 @@ spec:
       - name: agent
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["python", "agent/agent.py"]
+        command: ["python", "-m", "agent.agent"]
+        ports:
+        - name: http
+          containerPort: 8000
         securityContext:
           privileged: true
           capabilities:

--- a/charts/seccomp-diff/templates/agent-service.yaml
+++ b/charts/seccomp-diff/templates/agent-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: seccomp-diff-agent
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: seccomp-diff-agent
+spec:
+  clusterIP: None
+  selector:
+    app: seccomp-diff-agent
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 8000

--- a/charts/seccomp-diff/templates/deployment.yaml
+++ b/charts/seccomp-diff/templates/deployment.yaml
@@ -38,5 +38,8 @@ spec:
             memory: {{ .Values.resources.requests.memory }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: AGENT_ENDPOINTS
+          value: "http://seccomp-diff-agent.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.agent.port }}"
         command: ["flask"]
         args: ["run", "--debug"]

--- a/charts/seccomp-diff/templates/deployment.yaml
+++ b/charts/seccomp-diff/templates/deployment.yaml
@@ -15,7 +15,6 @@ spec:
       labels:
         app: seccomp-diff
     spec:
-      hostPID: true
       {{- if .Values.nodename }}
       affinity:
         podAffinity:
@@ -39,31 +38,5 @@ spec:
             memory: {{ .Values.resources.requests.memory }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        securityContext:
-          privileged: true  # Allow ptrace and host-level access
-          capabilities:
-            add:
-            - SYS_PTRACE  # Add ptrace capability
-        volumeMounts:
-        - name: host-proc
-          mountPath: /host/proc
-          readOnly: true
-        - name: docker-socket
-          mountPath: /var/run/docker.sock  # Mount Docker socket
-        - name: containerd-socket
-          mountPath: /var/run/containerd/containerd.sock  
-        env:
-        - name: PROC_PATH
-          value: "/host/proc"
         command: ["flask"]
         args: ["run", "--debug"]
-      volumes:
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: docker-socket
-        hostPath:
-          path: /var/run/docker.sock  # Host path for Docker socket
-      - name: containerd-socket
-        hostPath:
-          path: /var/run/containerd/containerd.sock  # Host path for Docker socket

--- a/charts/seccomp-diff/values.yaml
+++ b/charts/seccomp-diff/values.yaml
@@ -23,6 +23,10 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+agent:
+  enabled: true
+  port: 8000
+
 ## Custom profiles supported by default:
 # profile-block-all.json (Warning!! will likely not let you start a container)
 # profile-complain-unsafe.json

--- a/charts/seccomp-diff/values.yaml
+++ b/charts/seccomp-diff/values.yaml
@@ -26,6 +26,7 @@ affinity: {}
 agent:
   enabled: true
   port: 8000
+  containerdSocket: /run/containerd/containerd.sock
 
 ## Custom profiles supported by default:
 # profile-block-all.json (Warning!! will likely not let you start a container)

--- a/common/containerd.py
+++ b/common/containerd.py
@@ -99,15 +99,19 @@ def get_containers(containerd_socket="/run/containerd/containerd.sock", namespac
     channel = grpc.insecure_channel(f"unix://{containerd_socket}")
     client = containers_pb2_grpc.ContainersStub(channel)
 
+    response = None
     try:
         # Specify the namespace in the metadata
         metadata = (("containerd-namespace", namespace),)
         request = containers_pb2.ListContainersRequest()
-        response = client.List(request, metadata=metadata)       
+        response = client.List(request, metadata=metadata)
     except grpc.RpcError as e:
-        print(f"Error accessing containerd: {e}")    
-        
-    
+        print(f"Error accessing containerd: {e}")
+        return {}
+
+    if response is None:
+        return {}
+
     for container in response.containers:
         container_id = container.id
         name = container_id

--- a/common/diff.py
+++ b/common/diff.py
@@ -89,8 +89,12 @@ def compare_seccomp_policies(container1, container2, reduce=True, only_diff=True
         else:
             container2.setdefault("summary", {})
 
-        default_action1 = d1.defaultAction if d1 else "unknown"
-        default_action2 = d2.defaultAction if d2 else "unknown"
+        default_action1 = (
+            d1.defaultAction if d1 else container1.get("defaultAction", "unknown")
+        )
+        default_action2 = (
+            d2.defaultAction if d2 else container2.get("defaultAction", "unknown")
+        )
 
         console = Console()
         table = Table(show_header=True, show_lines=True, box=box.HEAVY_EDGE, style="green", pad_edge=False)

--- a/common/diff.py
+++ b/common/diff.py
@@ -60,7 +60,8 @@ def compare_seccomp_policies(container1, container2, reduce=True, only_diff=True
     
     try:
         if "summary" in container1:
-            full1, d1 = [], None
+            full1 = container1.get("filters", [])
+            d1 = None
         else:
             full1, d1 = get_seccomp_filters(container1["pid"])
         if container2 == "default":
@@ -73,19 +74,20 @@ def compare_seccomp_policies(container1, container2, reduce=True, only_diff=True
                 }
         else:
             if "summary" in container2:
-                full2, d2 = [], None
+                full2 = container2.get("filters", [])
+                d2 = None
             else:
                 full2, d2 = get_seccomp_filters(container2["pid"])
 
         if d1:
             container1["summary"] = d1.syscallSummary
         else:
-            container1["summary"] = {}
+            container1.setdefault("summary", {})
 
         if d2:
             container2["summary"] = d2.syscallSummary
         else:
-            container2["summary"] = {}
+            container2.setdefault("summary", {})
 
         default_action1 = d1.defaultAction if d1 else "unknown"
         default_action2 = d2.defaultAction if d2 else "unknown"

--- a/common/diff.py
+++ b/common/diff.py
@@ -59,17 +59,23 @@ def compare_seccomp_policies(container1, container2, reduce=True, only_diff=True
     danger_style = Style(color="red", blink=True, bold=True)
     
     try:
-        full1, d1 = get_seccomp_filters(container1["pid"])
+        if "summary" in container1:
+            full1, d1 = [], None
+        else:
+            full1, d1 = get_seccomp_filters(container1["pid"])
         if container2 == "default":
             full2, d2 = get_default_seccomp()
             container2 = {
-                "pid": None, 
+                "pid": None,
                 "name": "RuntimeDefault",
-                "seccomp": "", 
+                "seccomp": "",
                 "caps": "",
                 }
-        else: 
-            full2, d2 = get_seccomp_filters(container2["pid"])
+        else:
+            if "summary" in container2:
+                full2, d2 = [], None
+            else:
+                full2, d2 = get_seccomp_filters(container2["pid"])
 
         if d1:
             container1["summary"] = d1.syscallSummary

--- a/examples/deploy.yaml
+++ b/examples/deploy.yaml
@@ -30,10 +30,12 @@ spec:
         - name: docker-socket
           mountPath: /var/run/docker.sock  # OPTIONAL for Docker
         - name: containerd-socket
-          mountPath: /var/run/containerd/containerd.sock  
+          mountPath: /run/containerd/containerd.sock
         env:
         - name: PROC_PATH
           value: "/host/proc"
+        - name: CONTAINERD_SOCKET
+          value: /run/containerd/containerd.sock
         command: ["flask"]
         args: ["run", "--debug"]
       volumes:
@@ -45,4 +47,4 @@ spec:
           path: /var/run/docker.sock  # Host path for Docker socket
       - name: containerd-socket
         hostPath:
-          path: /var/run/containerd/containerd.sock  # Host path for Docker socket
+          path: /run/containerd/containerd.sock  # Host path for containerd socket (adjust for k3s)

--- a/web.py
+++ b/web.py
@@ -203,6 +203,8 @@ def run_seccomp_diff(reduce=True, only_diff=True, only_dangerous=False):
                         data = resp.json()
                         c["summary"] = data.get("summary", {})
                         c["filters"] = data.get("filters", [])
+                        if "defaultAction" in data:
+                            c["defaultAction"] = data["defaultAction"]
                     except Exception as e:
                         app.logger.error(f"error fetching seccomp from {c['agent_url']}: {e}")
 

--- a/web.py
+++ b/web.py
@@ -2,6 +2,7 @@ from common.diff import compare_seccomp_policies
 from common import containerd
 from common import docker
 from flask import Flask, render_template, render_template_string, request, jsonify, send_from_directory, abort
+import requests
 
 import json
 import markdown
@@ -12,6 +13,9 @@ app = Flask(__name__,
             static_folder="web/static",
             template_folder="web/templates",
             )
+
+AGENT_ENDPOINTS = [u.strip() for u in os.getenv("AGENT_ENDPOINTS", "").split(",") if u.strip()]
+app.config["AGENT_ENDPOINTS"] = AGENT_ENDPOINTS
 
 @app.route('/')
 def index():
@@ -35,6 +39,21 @@ def list_k8s(namespace="k8s.io"):
     for container, values in container_pids.items():
         containers.append(values)
     return {"containers": containers}
+
+
+def list_remote():
+    containers = []
+    for url in app.config["AGENT_ENDPOINTS"]:
+        try:
+            resp = requests.get(f"{url}/containers")
+            resp.raise_for_status()
+            data = resp.json()
+            for c in data.values():
+                c["agent_url"] = url
+                containers.append(c)
+        except Exception as e:
+            app.logger.error(f"error contacting agent {url}: {e}")
+    return {"containers": containers}
     
 
 @app.route('/list_containers', methods=['POST'])
@@ -42,9 +61,9 @@ def list_containers():
     """Return a list of running containers."""
     
     try:
-        if app.config["MODE"] == "Docker": 
-            # TODO testing if I need docker at all
-            #return jsonify(list_docker())
+        if app.config["AGENT_ENDPOINTS"]:
+            return jsonify(list_remote())
+        if app.config["MODE"] == "Docker":
             return jsonify(list_docker())
         else:
             return jsonify(list_k8s(namespace="k8s.io"))
@@ -175,9 +194,20 @@ def run_seccomp_diff(reduce=True, only_diff=True, only_dangerous=False):
     try:
         container1, container2 = container_selection
 
+        if app.config["AGENT_ENDPOINTS"]:
+            for c in (container1, container2):
+                if "agent_url" in c and "pid" in c:
+                    try:
+                        resp = requests.get(f"{c['agent_url']}/seccomp/{c['pid']}")
+                        resp.raise_for_status()
+                        data = resp.json()
+                        c["summary"] = data.get("summary", {})
+                    except Exception as e:
+                        app.logger.error(f"error fetching seccomp from {c['agent_url']}: {e}")
+
         # Generate the table using compare_seccomp_policies
         table,full1,full2 = compare_seccomp_policies(
-            container1, container2, 
+            container1, container2,
             reduce=reduce,
             only_diff=only_diff,
             only_dangerous=only_dangerous,

--- a/web.py
+++ b/web.py
@@ -202,6 +202,7 @@ def run_seccomp_diff(reduce=True, only_diff=True, only_dangerous=False):
                         resp.raise_for_status()
                         data = resp.json()
                         c["summary"] = data.get("summary", {})
+                        c["filters"] = data.get("filters", [])
                     except Exception as e:
                         app.logger.error(f"error fetching seccomp from {c['agent_url']}: {e}")
 


### PR DESCRIPTION
## Summary
- add a lightweight agent service for gathering seccomp data
- expose the agent as a DaemonSet and headless service in the helm chart
- make the web interface optionally query remote agents
- clean up the web deployment so it no longer needs host access
- document the new architecture

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sockfilter')*

------
https://chatgpt.com/codex/tasks/task_e_68559386dd44832c880e4f850e5d7b12