### PR TITLE
Ensure Service uses chart namespace

### DIFF
--- a/charts/seccomp-diff/templates/service.yaml
+++ b/charts/seccomp-diff/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
     name: seccomp-diff
+    namespace: {{ .Values.namespace }}
     labels:
         app: seccomp-diff
 


### PR DESCRIPTION
## Summary
- keep Deployment and Service in the same namespace
- add `namespace` to the Service template

## Testing
- `pytest -q` *(fails: No module named 'bcc')*

------
https://chatgpt.com/codex/tasks/task_e_6855974f6dcc832c860fb9bf479967c4