### PR TITLE
Improve socket error handling

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -20,7 +20,10 @@ AGENT_ID = os.getenv("HOSTNAME", "agent")
 @app.route('/containers', methods=['GET'])
 def list_containers():
     """Return container details for this node."""
-    info = containerd.get_containers(containerd_socket=CONTAINERD_SOCKET, namespace=NAMESPACE)
+    try:
+        info = containerd.get_containers(containerd_socket=CONTAINERD_SOCKET, namespace=NAMESPACE)
+    except (FileNotFoundError, PermissionError, containerd.ContainerdConnectionError) as e:
+        return jsonify({"error": str(e)}), 500
     for item in info.values():
         item["agent"] = AGENT_ID
     return jsonify(info)


### PR DESCRIPTION
## Summary
- raise an exception when failing to connect to containerd
- surface connection errors from the agent

## Testing
- `pip install bcc docker`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sockfilter')*

------
https://chatgpt.com/codex/tasks/task_e_6855c6dca968832c84f4a96cfbe198e8