### PR TITLE
Refactor seccomp diff backend to output docker-style JSON

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -30,16 +30,10 @@ def list_containers():
 
 @app.route('/seccomp/<int:pid>', methods=['GET'])
 def seccomp(pid):
-    """Return seccomp details for a given PID."""
-    filters, dis = ptrace.get_seccomp_filters(pid)
-    summary = dis.syscallSummary if dis else {}
-    default_action = dis.defaultAction if dis else None
-    return jsonify({
-        "pid": pid,
-        "filters": filters,
-        "summary": summary,
-        "defaultAction": default_action,
-    })
+    """Return seccomp profile for a given PID in Docker JSON format."""
+    profile = ptrace.get_seccomp_profile(pid)
+    profile["pid"] = pid
+    return jsonify(profile)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8000)

--- a/seccomp_diff.py
+++ b/seccomp_diff.py
@@ -81,7 +81,7 @@ def main():
             raise ValueError("Cannot compare a container to itself")
 
         # Compare seccomp policies
-        table, _, _ = compare_seccomp_policies(containers[container1], containers[container2])
+        table = compare_seccomp_policies(containers[container1], containers[container2])
         
         
         console.options.max_height = 5

--- a/web.py
+++ b/web.py
@@ -201,15 +201,12 @@ def run_seccomp_diff(reduce=True, only_diff=True, only_dangerous=False):
                         resp = requests.get(f"{c['agent_url']}/seccomp/{c['pid']}")
                         resp.raise_for_status()
                         data = resp.json()
-                        c["summary"] = data.get("summary", {})
-                        c["filters"] = data.get("filters", [])
-                        if "defaultAction" in data:
-                            c["defaultAction"] = data["defaultAction"]
+                        c["profile"] = data
                     except Exception as e:
                         app.logger.error(f"error fetching seccomp from {c['agent_url']}: {e}")
 
         # Generate the table using compare_seccomp_policies
-        table,full1,full2 = compare_seccomp_policies(
+        table = compare_seccomp_policies(
             container1, container2,
             reduce=reduce,
             only_diff=only_diff,
@@ -219,7 +216,7 @@ def run_seccomp_diff(reduce=True, only_diff=True, only_dangerous=False):
         
         
         # Convert the table to JSON
-        table_json = table_to_json(table, full1, full2)
+        table_json = table_to_json(table)
         return jsonify({"output": table_json})
     except ValueError as e:
         return jsonify({"diff error": str(e)}), 500


### PR DESCRIPTION
## Summary
- convert ptrace BPF output to Docker style seccomp JSON
- serve new JSON from the agent
- compare profiles using the JSON format
- adjust CLI, web and tests for new API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_6855ce7684d8832c9b781bfacf4ad467