### PR TITLE
Add k3s and image test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,16 @@ test/k8s:
 	docker push antitree/seccomp-diff:test
 	RUN_VAGRANT_TESTS=1 pytest tests/test_vagrant_k8s.py
 
+# Build and push test image only
+test/image:
+	docker build -t antitree/seccomp-diff:test .
+	docker push antitree/seccomp-diff:test
+
+# Deploy Helm chart to k3s using the test image and socket path
+test/k3s:
+	helm install seccomp-diff charts/seccomp-diff \
+		--set image.tag=test \
+		--set agent.containerdSocket=/run/k3s/containerd/containerd.sock
+
 test/py:
 	pytest


### PR DESCRIPTION
## Summary
- add `test/image` target to build & push `antitree/seccomp-diff:test`
- add `test/k3s` target to deploy chart with test image and k3s socket

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_6855d59f1bf0832cb65af027ee84c86c