### PR TITLE
Add kubeconfig extraction helper for vagrant

### DIFF
--- a/tools/vagrant-k3s/README.md
+++ b/tools/vagrant-k3s/README.md
@@ -17,7 +17,14 @@ curl http://localhost:5000
 
 The API server listens on the master's private IP `192.168.56.10`. The kubeconfig
 file is patched by the provisioning script so it can be used directly from the
-host machine. The `seccomp-diff` service is exposed on `localhost:5000`.
+host machine. If you need to re-extract the configuration run:
+
+```bash
+./extract_kubeconfig.sh
+```
+
+This script copies the kubeconfig from the master and adds `insecure-skip-tls-verify: true`
+so TLS certificate validation is skipped. The `seccomp-diff` service is exposed on `localhost:5000`.
 
 ### Loading local images
 

--- a/tools/vagrant-k3s/extract_kubeconfig.sh
+++ b/tools/vagrant-k3s/extract_kubeconfig.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Extract kubeconfig from the master node and patch it for host usage
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+vagrant ssh master -c 'sudo cat /etc/rancher/k3s/k3s.yaml' > kubeconfig
+
+# Replace localhost with master IP
+sed -i 's/127.0.0.1/192.168.56.10/' kubeconfig
+# Remove certificate authority data to avoid TLS validation
+sed -i '/certificate-authority-data/d' kubeconfig
+# Disable TLS verification
+sed -i "/server: https:\/\/192.168.56.10:6443/a\    insecure-skip-tls-verify: true" kubeconfig
+
+echo "Kubeconfig written to $(pwd)/kubeconfig"
+


### PR DESCRIPTION
## Summary
- add `extract_kubeconfig.sh` helper that adds insecure TLS option
- document the helper in `tools/vagrant-k3s/README.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_6856082ecb10832c911dbcc26d6bab0c