### PR TITLE
Fix container selection behavior

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -124,6 +124,12 @@ h1, h2, h3 {
     color: var(--selected-text) !important;
 }
 
+.disabled-container {
+    background-color: #d3d3d3 !important;
+    color: #6c757d !important;
+    cursor: not-allowed !important;
+}
+
 .header {
     background-color: var(--header-background);
     color: var(--header-color);

--- a/web/static/js/ui.js
+++ b/web/static/js/ui.js
@@ -83,12 +83,20 @@ function renderContainers(containers) {
             const button = document.createElement('button');
             const tooltip = document.createElement('span');
             bdiv.className = "tooltip-container";
-            
+
             tooltip.innerText = `${containerText}`;
             tooltip.className = "tooltip-text";
             button.textContent = `${container.name} (PID: ${container.pid})`;
-            button.className = "btn btn-outline-primary ";
-            button.onclick = () => toggleSelection(container, button);
+            button.dataset.pid = container.pid;
+
+            if (container.pid === null || container.pid === undefined) {
+                button.className = "btn btn-outline-secondary disabled-container";
+                button.disabled = true;
+            } else {
+                button.className = "btn btn-outline-primary ";
+                button.onclick = () => toggleSelection(container, button);
+            }
+
             bdiv.appendChild(button);
             bdiv.appendChild(tooltip);
             containerDiv.appendChild(bdiv);
@@ -125,11 +133,22 @@ function filterByNamespace() {
 }
 
 function toggleSelection(container, button) {
+    if (container.pid === null || container.pid === undefined) {
+        return;
+    }
+
     const exists = selectedContainers.find(c => c.pid === container.pid);
     if (exists) {
         selectedContainers = selectedContainers.filter(c => c.pid !== container.pid);
         button.classList.remove('selected');
-    } else if (selectedContainers.length < 2) {
+    } else {
+        if (selectedContainers.length >= 2) {
+            const removed = selectedContainers.shift();
+            const oldButton = document.querySelector(`button[data-pid='${removed.pid}']`);
+            if (oldButton) {
+                oldButton.classList.remove('selected');
+            }
+        }
         selectedContainers.push(container);
         button.classList.add('selected');
     }


### PR DESCRIPTION
## Summary
- mark containers without PIDs as disabled
- add button dataset for container PID
- implement FIFO behavior when selecting more than two containers
- style disabled container buttons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_68575622f4b4832c9dea112924151cae